### PR TITLE
Change URI.escase deprecated encoding in ruby 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 Gemfile.lock
 doc
 coverage
+.tool-versions

--- a/lib/adal/user_credential.rb
+++ b/lib/adal/user_credential.rb
@@ -65,7 +65,7 @@ module ADAL
       @username = username
       @password = password
       @authority_host = authority_host
-      @discovery_path = "/common/userrealm/#{URI.escape @username}"
+      @discovery_path = "/common/userrealm/#{URI::DEFAULT_PARSER.escape @username}"
     end
 
     ##


### PR DESCRIPTION
before
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/1177575/164161728-7f613a7a-37c9-4d35-b8eb-545233452392.png">

after
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/1177575/164161690-f5c52c53-fd9c-4245-8422-f9e0e787a36b.png">
